### PR TITLE
update license holder name and attributions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019-2021 repl-it-electron contributors
+   Copyright 2019-21 Replit-Desktop Developement Team
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updated the holder name to include only the dev team, not all contributors. Attributing everyone who forks, clones, or commits to the project would be dumb and a huge pain. 👍🏽 